### PR TITLE
Slim

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: forecastML
 Type: Package
 Title: Time-Series Forecasting with Machine Learning Methods
-Version: 0.4.0
+Version: 0.4.1
 Author: Nickalus Redell
 Maintainer: Nickalus Redell <nickalusredell@gmail.com>
 Description: The purpose of forecastML is to provide a series of functions and visualizations that simplify the process of multi-step-ahead direct forecasting with standard machine learning algorithms. It's a wrapper package aimed at providing maximum flexibility in model-building--choose any machine learning algorithm from any R package--while helping the user quickly assess the (a) accuracy, (b) stability, and (c) generalizability of grouped (i.e., multiple related time-series) and ungrouped single-outcome forecasts produced from potentially high-dimensional modeling datasets. This package is inspired by Bergmeir, Hyndman, and Koo's 2018 paper "A note on the validity of cross-validation for evaluating autoregressive time series prediction" <https://robjhyndman.com/papers/cv-wp.pdf>. 

--- a/R/create_windows.R
+++ b/R/create_windows.R
@@ -14,11 +14,11 @@
 #' @param skip Optional. An integer giving a fixed number of dataset rows/time to skip between validation datasets. If dates were given
 #' in \code{create_lagged_df}, the time between validation windows is \code{skip} * 'date frequency'.
 #' @param include_partial_window Boolean. If \code{TRUE}, keep validation datasets that are shorter than \code{window_length}.
-#' @return An S3 object if class 'windows': A data.frame giving the indices for the validation datasets.
+#' @return An S3 object of class 'windows': A data.frame giving the indices for the validation datasets.
 #'
 #' @section Methods and related functions:
 #'
-#' The output of of \code{create_windows()} is passed into
+#' The output of \code{create_windows()} is passed into
 #'
 #' \itemize{
 #'   \item \code{\link{train_model}}

--- a/R/examples/example_predict_train_model.R
+++ b/R/examples/example_predict_train_model.R
@@ -46,11 +46,12 @@ prediction_function <- function(model, data_features) {
 }
 
 # Predict on the validation datasets.
-data_valid <- predict(model_results, prediction_function = list(prediction_function))
+data_valid <- predict(model_results, prediction_function = list(prediction_function),
+                      data = data_train)
 
 # Forecast.
 data_forecast <- create_lagged_df(data_seatbelts, type = "forecast", outcome_cols = 1,
                                   lookback = lookback, horizon = horizons)
 data_forecasts <- predict(model_results, prediction_function = list(prediction_function),
-                          data_forecast = data_forecast)
+                          data = data_forecast)
 }

--- a/R/examples/example_return_error.R
+++ b/R/examples/example_return_error.R
@@ -46,7 +46,8 @@ prediction_function <- function(model, data_features) {
 }
 
 # Predict on the validation datasets.
-data_valid <- predict(model_results, prediction_function = list(prediction_function))
+data_valid <- predict(model_results, prediction_function = list(prediction_function),
+                      data = data_train)
 
 # Forecast error metrics for validation datasets.
 data_error <- return_error(data_valid)

--- a/R/examples/example_return_hyper.R
+++ b/R/examples/example_return_hyper.R
@@ -46,7 +46,8 @@ prediction_function <- function(model, data_features) {
 }
 
 # Predict on the validation datasets.
-data_valid <- predict(model_results, prediction_function = list(prediction_function))
+data_valid <- predict(model_results, prediction_function = list(prediction_function),
+                      data = data_train)
 
 # User-defined hyperparameter function - LASSO
 # The hyperparameter function should take one positional argument--the returned model

--- a/R/return_hyper.R
+++ b/R/return_hyper.R
@@ -76,8 +76,10 @@ return_hyper <- function(forecast_model, hyper_function = NULL) {
 #' Plot hyperparameter stability and relationship with error metrics across validation datasets.
 #'
 #' @param x An object of class 'forecast_model_hyper' from \code{return_hyper()}.
-#' @param data_results An object of class 'training_results' from \code{predict.forecast_model(..., data_forecast = NULL)}.
-#' @param data_error An object of class 'validation_error' from \code{return_error(..., data_test = NULL)}.
+#' @param data_results An object of class 'training_results' from
+#' \code{predict.forecast_model(..., data_forecast = NULL)}.
+#' @param data_error An object of class 'validation_error' from
+#' \code{return_error(..., data_test = NULL)}.
 #' @param type Select plot type; 'stability' is the default plot.
 #' @param horizons Optional. A numeric vector to filter results by horizon.
 #' @param windows Optional. A numeric vector to filter results by validation window number.
@@ -219,7 +221,7 @@ plot.forecast_model_hyper <- function(x, data_results, data_error,
     p <- p + facet_grid(error_metric ~ hyper, scales = "free")
     p <- p + theme_bw()
     p <- p + xlab("Hyperparameter value") + ylab("Error metric") +
-      labs(color = "Horizon") + ggtitle("Forecast Error and Hyperparameter Values - Faceted by horizon")
+      labs(color = "Horizon") + ggtitle("Forecast Error and Hyperparameter Values")
     return(p)
   }
 }

--- a/R/train_model.R
+++ b/R/train_model.R
@@ -172,50 +172,35 @@ train_model <- function(lagged_df, windows, model_function, model_name, use_futu
 #' @return If \code{data = create_lagged_df(..., type = "forecast")}, an S3 object of class 'training_results'. If
 #' \code{data = create_lagged_df(..., type = "forecast")}, an S3 object of class 'forecast_results'.
 #'
-#' \describe{
-#'   \item \strong{Columns in returned 'training_results' data.frame:}{
+#'   \strong{Columns in returned 'training_results' data.frame:}
 #'     \itemize{
 #'       \item \code{model}: User-supplied model name in \code{train_model()}.
 #'       \item \code{horizon}: Forecast horizons, 1:h, measured in dataset rows.
 #'       \item \code{window_length}: Validation window length measured in dataset rows.
-#'       \item \code{valid_indices}: Validation dataset row names from
-#'       \code{attributes(create_lagged_df())$row_indices}.
-#'       \item \code{date_indices}: If given, validation dataset date indices from
-#'       \code{attributes(create_lagged_df())$date_indices}.
+#'       \item \code{valid_indices}: Validation dataset row names from \code{attributes(create_lagged_df())$row_indices}.
+#'       \item \code{date_indices}: If given, validation dataset date indices from \code{attributes(create_lagged_df())$date_indices}.
 #'       \item \code{"groups"}: If given, the user_supplied groups in \code{create_lagged_df()}.
 #'       \item \code{"outcome_name"}: The target being forecasted.
 #'       \item \code{"outcome_name"_pred}: The model predictions.
-#'       \item \code{"outcome_name"_pred_lower}: If given, the lower prediction bounds returned by
-#'       the user-supplied prediction function.
-#'       \item \code{"outcome_name"_pred_upper}: If given, the upper prediction bounds returned by
-#'       the user-supplied prediction function.
-#'       }
-#'     }
-#'  }
+#'       \item \code{"outcome_name"_pred_lower}: If given, the lower prediction bounds returned by the user-supplied prediction function.
+#'       \item \code{"outcome_name"_pred_upper}: If given, the upper prediction bounds returned by the user-supplied prediction function.
+#'    }
 #'
-#'  \describe{
-#'   \item \strong{Columns in returned 'forecast_results' data.frame:}{
+#'    \strong{Columns in returned 'forecast_results' data.frame:}
 #'     \itemize{
 #'       \item \code{model}: User-supplied model name in \code{train_model()}.
-#'       \item \code{model_forecast_horizon}: The direct-forecasting time horizon that the model
-#'       was trained on.
+#'       \item \code{model_forecast_horizon}: The direct-forecasting time horizon that the model was trained on.
 #'       \item \code{horizon}: Forecast horizons, 1:h, measured in dataset rows.
 #'       \item \code{window_length}: Validation window length measured in dataset rows.
 #'       \item \code{window_number}: Validation dataset number.
-#'       \item \code{forecast_period}: The forecast period in row indices or dates. The forecast
-#'       period starts at either
-#'       \code{attributes(create_lagged_df())$data_stop + 1} for row indices or
-#'       \code{attributes(create_lagged_df())$data_stop + 1 * frequency} for date indices.
+#'       \item \code{forecast_period}: The forecast period in row indices or dates. The forecast period starts at either \code{attributes(create_lagged_df())$data_stop + 1} for row indices or \code{attributes(create_lagged_df())$data_stop + 1 * frequency} for date indices.
 #'       \item \code{"groups"}: If given, the user_supplied groups in \code{create_lagged_df()}.
 #'       \item \code{"outcome_name"}: The target being forecasted.
 #'       \item \code{"outcome_name"_pred}: The model forecasts.
-#'       \item \code{"outcome_name"_pred_lower}: If given, the lower forecast bounds returned by
-#'       the user-supplied prediction function.
+#'       \item \code{"outcome_name"_pred_lower}: If given, the lower forecast bounds returned by the user-supplied prediction function.
 #'       \item \code{"outcome_name"_pred_upper}: If given, the upper forecast bounds returned by
 #'       the user-supplied prediction function.
-#'       }
-#'     }
-#'   }
+#'    }
 #'
 #' @example /R/examples/example_predict_train_model.R
 #' @export

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ prediction_function <- function(model, data_features) {
 }
 
 # Predict on the validation datasets.
-data_valid <- predict(model_results, prediction_function = list(prediction_function))
+data_valid <- predict(model_results, prediction_function = list(prediction_function), data = data_train)
 
 #------------------------------------------------------------------------------
 # Plot forecasts for each validation dataset.
@@ -138,7 +138,7 @@ data_forecast <- forecastML::create_lagged_df(data_seatbelts, type = "forecast",
 
 # Forecasts.
 data_forecasts <- predict(model_results, prediction_function = list(prediction_function),
-                          data_forecast = data_forecast)
+                          data = data_forecast)
 
 plot(data_forecasts, data_seatbelts[-(1:150), ], as.numeric(row.names(data_seatbelts[-(1:150), ])), horizons = c(1, 6, 12))
 ```

--- a/man/create_lagged_df.Rd
+++ b/man/create_lagged_df.Rd
@@ -5,8 +5,8 @@
 \title{Create model training and forecasting datasets with lagged, grouped, and static features}
 \usage{
 create_lagged_df(data, type = c("train", "forecast"), outcome_cols = 1,
-  horizons, lookback = NULL, lookback_control = NULL, groups = NULL,
-  static_features = NULL, dates = NULL, frequency = NULL,
+  horizons, lookback = NULL, lookback_control = NULL, dates = NULL,
+  frequency = NULL, groups = NULL, static_features = NULL,
   use_future = FALSE)
 }
 \arguments{
@@ -37,6 +37,12 @@ and static feature columns should have a \code{lookback_control} value of 0. \co
 from the input dataset. Lags that don't support direct forecasting for a given horizon
 are silently dropped. Either \code{lookback} or \code{lookback_control} need to be specified.}
 
+\item{dates}{A vector or 1-column data.frame of dates with class 'Date'. The length of dates should equal \code{nrow(data)}. Required if \code{groups}
+are given.}
+
+\item{frequency}{Date frequency. A string taking the same input as \code{base::seq(..., by = "frequency")} e.g., '1 month', '7 days', etc.
+Required if \code{dates} are given.}
+
 \item{groups}{Column name(s) that identify the groups/hierarchies when multiple time-series are present. These columns are used as model predictors but
 are not lagged. Note that combining feature lags with grouped time-series will result in \code{NA} values throughout the data.}
 
@@ -44,16 +50,10 @@ are not lagged. Note that combining feature lags with grouped time-series will r
 These columns are used as model features but are not lagged.
 Note that combining feature lags with grouped time-series will result in \code{NA} values throughout the data.}
 
-\item{dates}{A vector or 1-column data.frame of dates with class 'Date'. The length of dates should equal \code{nrow(data)}. Required if \code{groups}
-are given.}
-
-\item{frequency}{A string taking the same input as \code{base::seq(..., by = "frequency")} e.g., '1 month', '7 days', etc.
-Required if \code{dates} are given.}
-
 \item{use_future}{Boolean. If \code{TRUE}, the \code{future} package is used for creating lagged data.frames.
 \code{multisession} or \code{multicore} futures are especially useful for (a) grouped time series with many groups and
 (b) high-dimensional datasets with many lags per feature. Run \code{future::plan(future::multiprocess)} prior to this
-function to set up multissession or multicore parallel dataset creating.}
+function to set up multissession or multicore parallel dataset creation.}
 }
 \value{
 An S3 object of class 'lagged_df' or 'grouped_lagged_df': A list of data.frames with new columns for the lagged/non-lagged features.
@@ -80,6 +80,28 @@ The contents of the returned data.frame(s) are as follows:
 Create a list of datasets with lagged, grouped, and static features to (a) train forecasting models for
 specified forecast horizons and (b) forecast into the future with a trained ML model.
 }
+\section{Attributes}{
+
+
+\itemize{
+  \item \code{names}: The horizon-specific datasets that can be accessed by \code{my_lagged_df$horizon_h} where 'h' gives
+  the forecast horizon.
+  \item \code{type}: Training, \code{train}, or forecasting, \code{forecast}, dataset(s).
+  \item \code{horizons}: Forecast horizons measured in dataset rows.
+  \item \code{outcome_cols}: The column index of the target being forecasted.
+  \item \code{outcome_names}: The name of the target being forecasted.
+  \item \code{predictor_names}: The predictor or feature names from the input dataset.
+  \item \code{row_indices}: The \code{row.names()} of the output dataset. For non-grouped datasets, the first
+  \code{lookback} + 1 rows are removed from the beginning of the dataset to remove \code{NA} values in the lagged features.
+  \item \code{date_indices}: If \code{dates} are given, the vector of \code{dates}.
+  \item \code{frequency}: If \code{dates} are given, the date/time frequency.
+  \item \code{data_start}: \code{min(row_indices)} or \code{min(date_indices)}.
+  \item \code{data_stop}: \code{max(row_indices)} or \code{max(date_indices)}.
+  \item \code{groups}: If \code{groups} are given, a vector of group names.
+  \item \code{class}: grouped_lagged_df, lagged_df, list
+}
+}
+
 \section{Methods and related functions}{
 
 

--- a/man/create_windows.Rd
+++ b/man/create_windows.Rd
@@ -25,7 +25,7 @@ in \code{create_lagged_df}, the time between validation windows is \code{skip} *
 \item{include_partial_window}{Boolean. If \code{TRUE}, keep validation datasets that are shorter than \code{window_length}.}
 }
 \value{
-An S3 object if class 'windows': A data.frame giving the indices for the validation datasets.
+An S3 object of class 'windows': A data.frame giving the indices for the validation datasets.
 }
 \description{
 Flexibly ceate blocks of time-contiguous validation datasets to assess the likely forecast accuracy
@@ -35,7 +35,7 @@ the outer loop of a nested cross-validation model training setup.
 \section{Methods and related functions}{
 
 
-The output of of \code{create_windows()} is passed into
+The output of \code{create_windows()} is passed into
 
 \itemize{
   \item \code{\link{train_model}}

--- a/man/plot.forecast_model_hyper.Rd
+++ b/man/plot.forecast_model_hyper.Rd
@@ -11,9 +11,11 @@
 \arguments{
 \item{x}{An object of class 'forecast_model_hyper' from \code{return_hyper()}.}
 
-\item{data_results}{An object of class 'training_results' from \code{predict.forecast_model(..., data_forecast = NULL)}.}
+\item{data_results}{An object of class 'training_results' from
+\code{predict.forecast_model(..., data_forecast = NULL)}.}
 
-\item{data_error}{An object of class 'validation_error' from \code{return_error(..., data_test = NULL)}.}
+\item{data_error}{An object of class 'validation_error' from
+\code{return_error(..., data_test = NULL)}.}
 
 \item{type}{Select plot type; 'stability' is the default plot.}
 
@@ -78,7 +80,8 @@ prediction_function <- function(model, data_features) {
 }
 
 # Predict on the validation datasets.
-data_valid <- predict(model_results, prediction_function = list(prediction_function))
+data_valid <- predict(model_results, prediction_function = list(prediction_function),
+                      data = data_train)
 
 # User-defined hyperparameter function - LASSO
 # The hyperparameter function should take one positional argument--the returned model

--- a/man/plot.forecast_results.Rd
+++ b/man/plot.forecast_results.Rd
@@ -10,13 +10,13 @@
   group_filter = NULL, ...)
 }
 \arguments{
-\item{x}{An object of class 'forecast_results' from \code{predict.forecast_model}.}
+\item{x}{An object of class 'forecast_results' from \code{predict.forecast_model()}.}
 
 \item{data_actual}{A data.frame containing the target/outcome name and any grouping columns.}
 
 \item{actual_indices}{Required if 'data_actual' is given. A vector or 1-column data.frame
 of numeric row indices or dates (class 'Date') with length \code{nrow(data_actual)}.
-The data can be historical and/or holdout/test data, forecasts and actuals are matched by row.names().}
+The data can be historical and/or holdout/test data, forecasts and actuals are matched by \code{row.names()}.}
 
 \item{models}{Optional. Filter results by user-defined model name from \code{train_model()}.}
 
@@ -27,13 +27,14 @@ The data can be historical and/or holdout/test data, forecasts and actuals are m
 \item{facet_plot}{Adjust the plot display through \code{ggplot2::facet_grid()}.
 \code{facet_plot = NULL} plots results in one facet.}
 
-\item{group_filter}{Optional. A string for filtering plot results for grouped time-series (e.g., \code{"group_col_1 == 'A'"}).}
+\item{group_filter}{Optional. A string for filtering plot results for grouped time-series (e.g., \code{"group_col_1 == 'A'"});
+passed to \code{dplyr::filter()} internally.}
 
-\item{...}{Arguments passed to \code{base::plot}}
+\item{...}{Arguments passed to \code{base::plot()}}
 }
 \value{
 Forecast plot of class 'ggplot'.
 }
 \description{
-A forecast plot for each horizon for each model in predict.forecast_model().
+A forecast plot for each horizon for each model in \code{predict.forecast_model()}.
 }

--- a/man/plot.training_results.Rd
+++ b/man/plot.training_results.Rd
@@ -31,6 +31,6 @@
 Diagnostic plots of class 'ggplot'.
 }
 \description{
-Several diagnostic plots can be returned to assess the quality of the forecats
-based on predictions on the outer-loop validation datasets.
+Several diagnostic plots can be returned to assess the quality of the forecasts
+based on predictions on the validation datasets.
 }

--- a/man/predict.forecast_model.Rd
+++ b/man/predict.forecast_model.Rd
@@ -5,7 +5,7 @@
 \title{Predict on validation datasets or forecast}
 \usage{
 \method{predict}{forecast_model}(..., prediction_function = list(NULL),
-  data_forecast = NULL)
+  data = NULL)
 }
 \arguments{
 \item{...}{One or more trained models from \code{train_model()}.}
@@ -18,17 +18,63 @@ of model predictions. If the prediction function returns a 1-column data.frame, 
 If the prediction function returns a 3-column data.frame, lower and upper forecast bounds are assumed (the
 order of the 3 columns does not matter). See the example below for details.}
 
-\item{data_forecast}{If \code{NULL}, predictions are returned for the validation datasets in each 'forecast_model'
-in .... If an object of class 'lagged_df' from \code{create_lagged_df(..., type = "forecast")}, forecasts from 1:h.}
+\item{data}{If \code{data} is a training dataset from \code{create_lagged_df(..., type = "train")}, validation dataset
+predictions are returned; else, if \code{data} is a forecasting dataset from \code{create_lagged_df(..., type = "forecast")},
+forecasts from horizons 1:h are returned.}
 }
 \value{
-If \code{data_forecast = NULL}, an S3 object of class 'training_results' object. If
-\code{data_forecast = create_lagged_df(..., type = "forecast")}, an S3 object of class 'forecast_results'.
+If \code{data = create_lagged_df(..., type = "forecast")}, an S3 object of class 'training_results'. If
+\code{data = create_lagged_df(..., type = "forecast")}, an S3 object of class 'forecast_results'.
+
+\describe{
+  \item \strong{Columns in returned 'training_results' data.frame:}{
+    \itemize{
+      \item \code{model}: User-supplied model name in \code{train_model()}.
+      \item \code{horizon}: Forecast horizons, 1:h, measured in dataset rows.
+      \item \code{window_length}: Validation window length measured in dataset rows.
+      \item \code{valid_indices}: Validation dataset row names from
+      \code{attributes(create_lagged_df())$row_indices}.
+      \item \code{date_indices}: If given, validation dataset date indices from
+      \code{attributes(create_lagged_df())$date_indices}.
+      \item \code{"groups"}: If given, the user_supplied groups in \code{create_lagged_df()}.
+      \item \code{"outcome_name"}: The target being forecasted.
+      \item \code{"outcome_name"_pred}: The model predictions.
+      \item \code{"outcome_name"_pred_lower}: If given, the lower prediction bounds returned by
+      the user-supplied prediction function.
+      \item \code{"outcome_name"_pred_upper}: If given, the upper prediction bounds returned by
+      the user-supplied prediction function.
+      }
+    }
+ }
+
+ \describe{
+  \item \strong{Columns in returned 'forecast_results' data.frame:}{
+    \itemize{
+      \item \code{model}: User-supplied model name in \code{train_model()}.
+      \item \code{model_forecast_horizon}: The direct-forecasting time horizon that the model
+      was trained on.
+      \item \code{horizon}: Forecast horizons, 1:h, measured in dataset rows.
+      \item \code{window_length}: Validation window length measured in dataset rows.
+      \item \code{window_number}: Validation dataset number.
+      \item \code{forecast_period}: The forecast period in row indices or dates. The forecast
+      period starts at either
+      \code{attributes(create_lagged_df())$data_stop + 1} for row indices or
+      \code{attributes(create_lagged_df())$data_stop + 1 * frequency} for date indices.
+      \item \code{"groups"}: If given, the user_supplied groups in \code{create_lagged_df()}.
+      \item \code{"outcome_name"}: The target being forecasted.
+      \item \code{"outcome_name"_pred}: The model forecasts.
+      \item \code{"outcome_name"_pred_lower}: If given, the lower forecast bounds returned by
+      the user-supplied prediction function.
+      \item \code{"outcome_name"_pred_upper}: If given, the upper forecast bounds returned by
+      the user-supplied prediction function.
+      }
+    }
+  }
 }
 \description{
-Predict with a 'forecast_model' object from \code{train_model()}. If \code{data_forecast = NULL},
+Predict with a 'forecast_model' object from \code{train_model()}. If \code{data = create_lagged_df(..., type = "train")},
 predictions are returned for the outer-loop nested cross-validation datasets.
-If \code{data_forecast} is an object of class 'lagged_df' from \code{create_lagged_df(..., type = "forecast")},
+If \code{data} is an object of class 'lagged_df' from \code{create_lagged_df(..., type = "forecast")},
 predictions are returned for the horizons specified in \code{create_lagged_df()}.
 }
 \examples{
@@ -80,12 +126,13 @@ prediction_function <- function(model, data_features) {
 }
 
 # Predict on the validation datasets.
-data_valid <- predict(model_results, prediction_function = list(prediction_function))
+data_valid <- predict(model_results, prediction_function = list(prediction_function),
+                      data = data_train)
 
 # Forecast.
 data_forecast <- create_lagged_df(data_seatbelts, type = "forecast", outcome_cols = 1,
                                   lookback = lookback, horizon = horizons)
 data_forecasts <- predict(model_results, prediction_function = list(prediction_function),
-                          data_forecast = data_forecast)
+                          data = data_forecast)
 }
 }

--- a/man/predict.forecast_model.Rd
+++ b/man/predict.forecast_model.Rd
@@ -26,50 +26,35 @@ forecasts from horizons 1:h are returned.}
 If \code{data = create_lagged_df(..., type = "forecast")}, an S3 object of class 'training_results'. If
 \code{data = create_lagged_df(..., type = "forecast")}, an S3 object of class 'forecast_results'.
 
-\describe{
-  \item \strong{Columns in returned 'training_results' data.frame:}{
+  \strong{Columns in returned 'training_results' data.frame:}
     \itemize{
       \item \code{model}: User-supplied model name in \code{train_model()}.
       \item \code{horizon}: Forecast horizons, 1:h, measured in dataset rows.
       \item \code{window_length}: Validation window length measured in dataset rows.
-      \item \code{valid_indices}: Validation dataset row names from
-      \code{attributes(create_lagged_df())$row_indices}.
-      \item \code{date_indices}: If given, validation dataset date indices from
-      \code{attributes(create_lagged_df())$date_indices}.
+      \item \code{valid_indices}: Validation dataset row names from \code{attributes(create_lagged_df())$row_indices}.
+      \item \code{date_indices}: If given, validation dataset date indices from \code{attributes(create_lagged_df())$date_indices}.
       \item \code{"groups"}: If given, the user_supplied groups in \code{create_lagged_df()}.
       \item \code{"outcome_name"}: The target being forecasted.
       \item \code{"outcome_name"_pred}: The model predictions.
-      \item \code{"outcome_name"_pred_lower}: If given, the lower prediction bounds returned by
-      the user-supplied prediction function.
-      \item \code{"outcome_name"_pred_upper}: If given, the upper prediction bounds returned by
-      the user-supplied prediction function.
-      }
-    }
- }
+      \item \code{"outcome_name"_pred_lower}: If given, the lower prediction bounds returned by the user-supplied prediction function.
+      \item \code{"outcome_name"_pred_upper}: If given, the upper prediction bounds returned by the user-supplied prediction function.
+   }
 
- \describe{
-  \item \strong{Columns in returned 'forecast_results' data.frame:}{
+   \strong{Columns in returned 'forecast_results' data.frame:}
     \itemize{
       \item \code{model}: User-supplied model name in \code{train_model()}.
-      \item \code{model_forecast_horizon}: The direct-forecasting time horizon that the model
-      was trained on.
+      \item \code{model_forecast_horizon}: The direct-forecasting time horizon that the model was trained on.
       \item \code{horizon}: Forecast horizons, 1:h, measured in dataset rows.
       \item \code{window_length}: Validation window length measured in dataset rows.
       \item \code{window_number}: Validation dataset number.
-      \item \code{forecast_period}: The forecast period in row indices or dates. The forecast
-      period starts at either
-      \code{attributes(create_lagged_df())$data_stop + 1} for row indices or
-      \code{attributes(create_lagged_df())$data_stop + 1 * frequency} for date indices.
+      \item \code{forecast_period}: The forecast period in row indices or dates. The forecast period starts at either \code{attributes(create_lagged_df())$data_stop + 1} for row indices or \code{attributes(create_lagged_df())$data_stop + 1 * frequency} for date indices.
       \item \code{"groups"}: If given, the user_supplied groups in \code{create_lagged_df()}.
       \item \code{"outcome_name"}: The target being forecasted.
       \item \code{"outcome_name"_pred}: The model forecasts.
-      \item \code{"outcome_name"_pred_lower}: If given, the lower forecast bounds returned by
-      the user-supplied prediction function.
+      \item \code{"outcome_name"_pred_lower}: If given, the lower forecast bounds returned by the user-supplied prediction function.
       \item \code{"outcome_name"_pred_upper}: If given, the upper forecast bounds returned by
       the user-supplied prediction function.
-      }
-    }
-  }
+   }
 }
 \description{
 Predict with a 'forecast_model' object from \code{train_model()}. If \code{data = create_lagged_df(..., type = "train")},

--- a/man/return_error.Rd
+++ b/man/return_error.Rd
@@ -117,7 +117,8 @@ prediction_function <- function(model, data_features) {
 }
 
 # Predict on the validation datasets.
-data_valid <- predict(model_results, prediction_function = list(prediction_function))
+data_valid <- predict(model_results, prediction_function = list(prediction_function),
+                      data = data_train)
 
 # Forecast error metrics for validation datasets.
 data_error <- return_error(data_valid)

--- a/man/return_hyper.Rd
+++ b/man/return_hyper.Rd
@@ -78,7 +78,8 @@ prediction_function <- function(model, data_features) {
 }
 
 # Predict on the validation datasets.
-data_valid <- predict(model_results, prediction_function = list(prediction_function))
+data_valid <- predict(model_results, prediction_function = list(prediction_function),
+                      data = data_train)
 
 # User-defined hyperparameter function - LASSO
 # The hyperparameter function should take one positional argument--the returned model

--- a/man/train_model.Rd
+++ b/man/train_model.Rd
@@ -13,7 +13,7 @@ train_model(lagged_df, windows, model_function, model_name,
 \item{windows}{An object of class 'windows' from \code{\link{create_windows}}.}
 
 \item{model_function}{A user-defined wrapper function for model training that takes 2
-positional arguments--(1) a data.frame made with \code{create_lagged_df} and
+positional arguments--(1) a data.frame made with \code{create_lagged_df()} and
 (2) the column index of the modeled outcome--and returns a model object which is used
 as input in the user-defined prediction function (see example).}
 
@@ -50,8 +50,8 @@ and has the following generic S3 methods
 
 \itemize{
   \item \code{\link[=predict.forecast_model]{predict}}
-  \item \code{\link[=plot.training_results]{plot}} (from \code{predict.forecast_model(data_forecast = NULL)})
-  \item \code{\link[=plot.forecast_results]{plot}} (from \code{predict.forecast_model(data_forecast = ...)})
+  \item \code{\link[=plot.training_results]{plot}} (from \code{predict.forecast_model(data = create_lagged_df(..., type = "train"))})
+  \item \code{\link[=plot.forecast_results]{plot}} (from \code{predict.forecast_model(data = create_lagged_df(..., type = "forecast"))})
 }
 }
 

--- a/vignettes/grouped_forecast.Rmd
+++ b/vignettes/grouped_forecast.Rmd
@@ -309,10 +309,13 @@ summary(model_results_cv$horizon_1$window_1$model)
 * Then we'll forecast with each of our 21 models to get a sense of the stability of the forecasts 
 produced from models trained on different subsets of our historical data.
 
-#### User-defined predict function
+#### User-defined prediction function
 
-* The function takes **2 positional arguments** and returns a 1-column data.frame. Future 
-versions of `forecastML` will support returning lower and upper forecast bounds.
+* A wrapper function that takes the following **positional arguments**:
+    * **1:** The model returned from the user-defined modeling function.
+    * **2:** A `data.frame()` of the model predictors from `forecastML::create_lagged_df(type = "train")`.
+* and **returns** a `data.frame()` of predictions with 1 or 3 columns. A 1-column data.frame will produce point forecasts, 
+and a 3-column data.frame can be used to return point, lower, and upper forecasts (column names and order do not matter).
 
 ```{r}
 prediction_function <- function(model, data_features) {
@@ -328,11 +331,10 @@ prediction_function <- list(prediction_function)
 
 #### Historical model fit
 
-* We're predicting on our validation datasets because we haven't specified the `data_forecast` argument 
-in `predict()`
+* We're predicting on our validation datasets.
 
 ```{r}
-data_pred_cv <- predict(model_results_cv, prediction_function = prediction_function)
+data_pred_cv <- predict(model_results_cv, prediction_function = prediction_function, data = data_train)
 
 print(paste0("The class of `data_pred_cv` is ", class(data_pred_cv)))
 ```
@@ -390,7 +392,7 @@ DT::datatable(head(data_forecast$horizon_1), options = list(scrollX = TRUE))
 
 ```{r}
 data_forecasts <- predict(model_results_cv, prediction_function = prediction_function, 
-                          data_forecast = data_forecast)
+                          data = data_forecast)
 
 print(paste0("The class of `data_forecasts` is ", class(data_forecasts)))
 ```
@@ -433,6 +435,7 @@ p
 ***
 
 ```{r}
+# Un-comment the code below and set 'use_future' to TRUE.
 #future::plan(future::multiprocess)
 
 model_results_no_cv <- forecastML::train_model(lagged_df = data_train, 
@@ -451,7 +454,7 @@ print(paste0("The class of `model_results_no_cv` is ", class(model_results_no_cv
 
 ```{r}
 data_forecasts <- predict(model_results_no_cv, prediction_function = prediction_function, 
-                          data_forecast = data_forecast)
+                          data = data_forecast)
 
 print(paste0("The class of `data_forecasts` is ", class(data_forecasts)))
 ```

--- a/vignettes/package_overview.Rmd
+++ b/vignettes/package_overview.Rmd
@@ -12,13 +12,6 @@ vignette: >
 
 ![](forecastML_logo.png){width=150px, height=160px}
 
-```{r, eval = FALSE, echo = FALSE, out.extra = 'style = "position:absolute; top:0; right:0; padding:5px; width: 150px; height: 160px;"'}
-# htmltools::img(src = knitr::image_uri("forecastML_logo.png"), 
-#                alt = 'logo', 
-#                style = 'position:absolute; top:0; right:0; padding:5px; width: 150px; height: 160px;')
-#knitr::include_graphics("forecastML_logo.png")
-```
-
 # Purpose
 
 The purpose of `forecastML` is to provide a series of functions and visualizations that simplify the process of 
@@ -85,7 +78,6 @@ forecast horizons with `forecastML::create_lagged_df`
 6. Create datasets of lagged predictors for **direct forecasting**.
 
 
-
 ```{r, include = FALSE}
 knitr::opts_chunk$set(fig.width = 6, fig.height = 4)
 ```
@@ -93,7 +85,7 @@ knitr::opts_chunk$set(fig.width = 6, fig.height = 4)
 # Example
 
 In this walkthrough of `forecastML` we'll compare the forecast performance of two machine learning 
-methods, LASSO and Random Forest, across forecast horizons using the Seatbelts dataset from the `dataset` package.
+methods, LASSO and Random Forest, across forecast horizons using the Seatbelts dataset from the `datasets` package.
 
 Here's a summary of the problem at hand:
 
@@ -149,7 +141,6 @@ p
 ```
 
 
-
 <br>
 
 # Data Preparation
@@ -166,17 +157,13 @@ data_list <- forecastML::create_lagged_df(data_train, type = "train",
                                           horizons = horizons)
 ```
 
-
-
 <br>
 
 Let's view the modeling dataset for a forecast horion of 6.
 
 ```{r}
-DT::datatable(head(data_list[[6]], 10), options = list(scrollX = TRUE))
+DT::datatable(head(data_list$horizon_6, 10), options = list(scrollX = TRUE))
 ```
-
-
 
 <br>
 
@@ -188,8 +175,6 @@ for direct forecasting at a given forecast horizon are removed from the modeling
 ```{r}
 plot(data_list)
 ```
-
-
 
 <br>
 
@@ -208,8 +193,6 @@ windows <- forecastML::create_windows(lagged_df = data_list, window_length = 12,
 windows
 ```
 
-
-
 <br>
 
 Below is a plot of the nested cross-validation outer loop datasets or windows. In our example, 
@@ -224,25 +207,23 @@ the inner validation loop.
 plot(windows, data_list, show_labels = TRUE)
 ```
 
-
-
 <br>
 
 # Model Training
 
-## User-defined forecast function
+## User-defined prediction function
 
 We'll compare the forecasting performance of two models: (a) a cross-validated LASSO and (b) a non-tuned Random Forest. 
 The following user-defined functions are needed for each model:
 
-* A wrapper function that takes the following positional **arguments**:
-    * **1:** The input dataset with both target and model predictors. The predictor lags will be created according to the 
-    `forecastML::create_lagged_df()` function.
-    * **2:** The column index of the outcome to be forecasted. *Only 1 outcome can be modeled at present*.
-* and **returns** a fitted model suitable for a `predict()`-type function.
+* A wrapper function that takes the following **positional arguments**:
+    * **1:** The model returned from the user-defined modeling function.
+    * **2:** A `data.frame()` of the model predictors from `forecastML::create_lagged_df(type = "train")`.
+* and **returns** a `data.frame()` of predictions with 1 or 3 columns. A 1-column data.frame will produce point forecasts, 
+and a 3-column data.frame can be used to return point, lower, and upper forecasts (column names and order do not matter).
 
-Any inner loop cross-validation procedure should take place within this function, with the limitation that 
-the inner cross-validation needs to ultimately `return()` one model.
+Any data transformations, hyperparameter tuning, or inner loop cross-validation procedures should take place within this 
+function, with the limitation that it ultimately needs to `return()` one model.
 
 ```{r}
 # Example 1 - LASSO
@@ -270,7 +251,7 @@ model_function_2 <- function(data, outcome_cols = 1) {
 
 <br>
 
-## forecastML::train_model
+## `forecastML::train_model`
 
 For each modeling approach, LASSO and Random Forest, a total of `N forecast horizons` * `N validation windows` 
 models are trained. In this example, that means training **`r length(data_list) * nrow(windows[[1]])` models** 
@@ -289,10 +270,11 @@ model_results_2 <- forecastML::train_model(lagged_df = data_list, windows,
 
 The following user-defined prediction function is needed for each model:
 
-* A wrapper function that takes the following positional **arguments**:
+* A wrapper function that takes the following **positional arguments**:
     * **1:** The model returned from the user-defined modeling function.
-    * **2:** A `data.frame()` of the model predictors. Do not manually create the lagged predictors.
-* and **returns** a `data.frame()` of predictions with 1 column for each forecast target (limit 1 at present).
+    * **2:** A `data.frame()` of the model predictors from `forecastML::create_lagged_df(type = "train")`.
+* and **returns** a `data.frame()` of predictions with 1 or 3 columns. A 1-column data.frame will produce point forecasts, 
+and a 3-column data.frame can be used to return point, lower, and upper forecasts (column names and order do not matter).
 
 ```{r}
 # Example 1 - LASSO
@@ -314,7 +296,7 @@ prediction_function_2 <- function(model, data_features) {
 
 <br>
 
-## forecastML::predict
+## `forecastML::predict`
 
 The `predict.forecast_model()` method takes any number of trained models from `forecastML::train_model()` and a 
 list of user-defined prediction functions. The list of prediction functions should appear in the same order 
@@ -325,8 +307,7 @@ validation window.
 
 ```{r}
 data_results <- predict(model_results, model_results_2,
-                        prediction_function = list(prediction_function, prediction_function_2))
-
+                        prediction_function = list(prediction_function, prediction_function_2), data = data_list)
 ```
 
 <br>
@@ -344,8 +325,6 @@ Let's view the models' predictions. The data.frame with S3 class `training_resul
 DT::datatable(head(data_results, 10), options = list(scrollX = TRUE))
 ```
 
-
-
 <br>
 
 Below is a plot of the forecasts for each validation window at select forecast horizons.
@@ -354,8 +333,6 @@ Below is a plot of the forecasts for each validation window at select forecast h
 plot(data_results, type = "prediction", horizons = c(1, 6, 12))
 ```
 
-
-
 <br>
 
 Below is a plot of the forecast error for select validation windows at select forecast horizons.
@@ -363,8 +340,6 @@ Below is a plot of the forecast error for select validation windows at select fo
 ```{r}
 plot(data_results, type = "residual", horizons = c(1, 6, 12), windows = 10:14)
 ```
-
-
 
 <br>
 
@@ -380,8 +355,6 @@ plot(data_results, type = "forecast_stability", windows = max(data_results$windo
 plot(data_results, type = "forecast_stability", valid_indices = attributes(data_list)$row_indices[1:3])
 ```
 
-
-
 <br>
 
 The `forecast_variability` plot below is a summary of the `forecast_stability` plot. It's a plot 
@@ -393,18 +366,17 @@ provided the forecasts are increasingly accruate at shorter and shorter forecast
 plot(data_results, type = "forecast_variability", valid_indices = 30:80)
 ```
 
-
-
 <br>
 
 # Model Performance
 
-## forecastML::return_error
+## `forecastML::return_error`
 
 Let's calcuate several common forecast error metrics.
 
 * **mae:** Mean absolute error
 * **mape:** Mean absolute percentage error
+* **mdape:** Median absolute percentage error
 * **smape:** Symmetrical mean absolute percentage error from (Chen and Yang's 2004 formula with a 100% multiplier as 
 discussed at [https://robjhyndman.com/hyndsight/smape/](https://robjhyndman.com/hyndsight/smape/))
 
@@ -420,9 +392,7 @@ data_error <- forecastML::return_error(data_results, metrics = c("mae", "mape", 
 
 DT::datatable(data_error$error_global, options = list(scrollX = TRUE))
 ```
- 
- 
- 
+
 <br>
  
 Below is a plot of error metrics across time for select validation windows and forecast horizons.
@@ -430,8 +400,6 @@ Below is a plot of error metrics across time for select validation windows and f
 ```{r}
 plot(data_error, data_results, type = "time", horizons = c(1, 6, 12), windows = 10:14)
 ```
-
-
 
 <br>
 
@@ -442,8 +410,6 @@ validation windows (dark).
 plot(data_error, data_results, type = "horizon", horizons = c(1, 6, 12))
 ```
 
-
-
 <br>
 
 Below is a plot of error metrics collapsed across validation windows and forecast horizons.
@@ -451,8 +417,6 @@ Below is a plot of error metrics collapsed across validation windows and forecas
 ```{r}
 plot(data_error, data_results, type = "global")
 ```
-
-
 
 <br>
 
@@ -469,9 +433,9 @@ strategies to forecast well under various conditions or time-series dynamics.
 
 The following user-defined hyperparameter function is needed for each model:
 
-* A wrapper function that takes the following positional **arguments**
+* A wrapper function that takes the following **positional arguments**
     * **1:** The model returned from the user-defined modeling function.
-* and **returns** a `data.frame()` of predictions with 1 column for each forecast outcome.
+* and **returns** a 1-row `data.frame()`.
 
 ```{r}
 hyper_function <- function(model) {
@@ -486,7 +450,7 @@ hyper_function <- function(model) {
 
 <br>
 
-## forecastML::return_hyper
+## `forecastML::return_hyper`
 
 Below are two plots which show (a) univariate hyperparameter variability across the training data 
 and (b) the relationship between each error metric and hyperparameter values.
@@ -498,13 +462,11 @@ plot(data_hyper, data_results, data_error, type = "stability", horizons = c(1, 6
 plot(data_hyper, data_results, data_error, type = "error", c(1, 6, 12))
 ```
 
-
-
 <br>
 
 # Forecast
 
-## forecastML::create_lagged_df
+## `forecastML::create_lagged_df`
 
 To forecast with the direct forecasting method, we need to create another dataset of lagged predictors. 
 We can do this by running `create_lagged_df()` and setting `type = "forecast"`.
@@ -522,14 +484,12 @@ data_forecast_list <- forecastML::create_lagged_df(data_train, type = "forecast"
 DT::datatable(head(data_forecast_list$horizon_6), options = list(scrollX = TRUE))
 ```
 
-
-
 <br>
 
 ## Forecast results
 
 Running the predict method, `predict.forecast_model()`, on the lagged predictor dataset created 
-above--with `type = "forecast"`--and placing it in the `data_forecast` argument in `predict.forecast_model()` below, returns 
+above--with `type = "forecast"`--and placing it in the `data` argument in `predict.forecast_model()` below, returns 
 a data.frame of forecasts with the following columns:
 
 * **model:** User-defined model name.
@@ -546,12 +506,10 @@ the `training_results` class from earlier.
 ```{r}
 data_forecast <- predict(model_results, model_results_2,
                          prediction_function = list(prediction_function, prediction_function_2), 
-                         data_forecast = data_forecast_list)
+                         data = data_forecast_list)
 
 DT::datatable(head(data_forecast, 10), options = list(scrollX = TRUE))
 ```
-
-
 
 <br>
 
@@ -569,8 +527,6 @@ plot(data_forecast, data_actual = data_test,
      actual_indices = as.numeric(row.names(data_test)),
      facet_plot = "model", horizons = c(1, 6, 12))
 ```
-
-
 
 <br>
 
@@ -595,8 +551,6 @@ data_error <- forecastML::return_error(data_forecast, data_test = data_test,
 DT::datatable(head(data_error$error_by_horizon, 10), options = list(scrollX = TRUE))
 ```
 
-
-
 <br>
 
 # Model Selection and Re-training
@@ -607,7 +561,7 @@ Note that for a real-world forecasting problem this is when we would do addition
 to imrpove forecast accuracy across validation windows as well as narrow the hyperparameter search 
 in the user-specified modeling functions.
 
-## forecastML::create_lagged_df
+## `forecastML::create_lagged_df`
 
 ```{r}
 data_list <- forecastML::create_lagged_df(data_train, type = "train", 
@@ -617,9 +571,9 @@ data_list <- forecastML::create_lagged_df(data_train, type = "train",
 
 <br>
 
-## forecastML::create_windows
+## `forecastML::create_windows`
 
-To create a dataset *without nested cross-validation*, set `window_length = 0` in `forecastML::create_windows()`.
+To create a dataset *without nested cross-validation*, set **`window_length = 0`** in `forecastML::create_windows()`.
 
 ```{r}
 windows <- forecastML::create_windows(data_list, window_length = 0)
@@ -627,18 +581,16 @@ windows <- forecastML::create_windows(data_list, window_length = 0)
 plot(windows, data_list, show_labels = TRUE)
 ```
 
-
-
 <br>
 
-## forecastML::train_model
+## `forecastML::train_model`
 
 Without nested cross-validation and holdout windows, the prediction plot is essnetially a plot of model fit.
 
 ```{r}
 model_results <- forecastML::train_model(data_list, windows, model_function, model_name = "LASSO")
 
-data_results <- predict(model_results, prediction_function = list(prediction_function))
+data_results <- predict(model_results, prediction_function = list(prediction_function), data = data_list)
 
 DT::datatable(head(data_results, 10), options = list(scrollX = TRUE))
 plot(data_results, type = "prediction", horizons = c(1, 6, 12))
@@ -646,11 +598,9 @@ plot(data_results, type = "residual", horizons = c(1, 6, 12))
 plot(data_results, type = "forecast_stability", valid_indices = 109:120)
 ```
 
-
-
 <br>
 
-## forecastML::return_error
+## `forecastML::return_error`
 
 ```{r}
 data_error <- forecastML::return_error(data_results, metrics = c("mae", "mape", "mdape", "smape"),
@@ -662,7 +612,7 @@ plot(data_error, data_results, type = "horizon")
 
 
 
-## forecastML::return_hyper
+## `forecastML::return_hyper`
 
 ```{r}
 data_hyper <- forecastML::return_hyper(model_results, hyper_function)
@@ -670,8 +620,6 @@ data_hyper <- forecastML::return_hyper(model_results, hyper_function)
 plot(data_hyper, data_results, data_error, type = "stability", horizons = c(1, 6, 12))
 plot(data_hyper, data_results, data_error, type = "error", c(1, 6, 12))
 ```
-
-
 
 <br>
 
@@ -682,7 +630,7 @@ data_forecast_list <- forecastML::create_lagged_df(data_train, type = "forecast"
                                                   lookback = lookback,  horizon = horizons)
 
 data_forecast <- predict(model_results, prediction_function = list(prediction_function), 
-                         data_forecast = data_forecast_list)
+                         data = data_forecast_list)
 
 plot(data_forecast, data_actual = data[-(1:150), ],
      actual_indices = as.numeric(row.names(data[-(1:150), ])),
@@ -692,8 +640,6 @@ plot(data_forecast, data_actual = data[-(1:150), ],
 plot(data_forecast, data_actual = data_test, actual_indices = as.numeric(row.names(data_test)),
      facet_plot = NULL, horizons = c(1, 6, 12))
 ```
-
-
 
 <br>
 


### PR DESCRIPTION
The main change is that forecast_model objects no longer store a copy of the validation dataset; rather, the predict(..., data_forecast = NULL) methods has been changed to predict(..., data = NULL) to working with training and forecasting datasets. This is the expected behavior from a predict() function.